### PR TITLE
Harden security alerts and workflows

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -31,10 +31,10 @@ jobs:
         - language: python
         - language: javascript-typescript
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.6
+      uses: github/codeql-action/init@9e3211c9a3b9311dfe05da2ed48eea3386f042dd # v4.37.6
       with:
         languages: ${{ matrix.language }}
     - name: Perform CodeQL analysis
-      uses: github/codeql-action/analyze@v4.37.6
+      uses: github/codeql-action/analyze@9e3211c9a3b9311dfe05da2ed48eea3386f042dd # v4.37.6

--- a/.github/workflows/ha.yaml
+++ b/.github/workflows/ha.yaml
@@ -21,5 +21,5 @@ jobs:
     name: Hassfest
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v7
-    - uses: home-assistant/actions/hassfest@master
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+    - uses: home-assistant/actions/hassfest@a7c616ce81ccda50150bf1595786c71b1883fabb # master

--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -21,9 +21,9 @@ jobs:
     name: HACS
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: HACS Action
-      uses: hacs/action@main
+      uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main
       with:
         category: integration
         ignore: brands

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -22,13 +22,13 @@ jobs:
     outputs:
       versions: ${{ steps.generate-versions.outputs.versions }}
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:
         python-version: '3.13'
     - name: Install uv
-      uses: astral-sh/setup-uv@v9.0.0
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
     - name: Install dependencies
       run: uv pip sync --system --strict requirements.test
     - name: Generate versions
@@ -43,16 +43,16 @@ jobs:
       matrix:
         ha_version: ${{ fromJSON(needs.generate_versions.outputs.versions) }}
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:
         python-version: '3.13'
-    - uses: docker/setup-compose-action@v2
+    - uses: docker/setup-compose-action@4eb059ff7f16592f9c84d5ca339c53cb7c5064e2 # v2
       with:
         version: latest
     - name: Install uv
-      uses: astral-sh/setup-uv@v9.0.0
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
     - name: Install dependencies
       run: uv pip sync --system --strict requirements.test
     - name: Integration tests (${{ matrix.ha_version}})
@@ -65,4 +65,4 @@ jobs:
     needs: [test]
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -18,13 +18,13 @@ jobs:
   pre-commit:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:
         python-version: '3.13'
     - name: Install uv
-      uses: astral-sh/setup-uv@v9.0.0
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
     - name: Install dependencies
       run: |
         uv venv --python 3.13

--- a/.github/workflows/release-assets.yaml
+++ b/.github/workflows/release-assets.yaml
@@ -7,14 +7,14 @@ on:
     - published
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   upload-hacs-zip:
     name: Upload HACS zip
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         ref: ${{ github.event.release.tag_name }}
     - name: Build HACS release zip
@@ -26,6 +26,7 @@ jobs:
         python scripts/validate_hacs_zip.py ip-ban-manager.zip
     - name: Upload release asset
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       run: |
+        test -n "$GH_TOKEN"
         gh release upload "${{ github.event.release.tag_name }}" ip-ban-manager.zip --clobber

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,14 +18,11 @@ jobs:
     name: Renovate
     runs-on: ubuntu-24.04
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
       security-events: read
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Run Renovate
-      uses: renovatebot/github-action@v46.2.1
+      uses: renovatebot/github-action@316d7cd859606d6039a2182b7d69199e9b036835 # v46.2.1
       env:
         LOG_LEVEL: info
         RENOVATE_CONFIG_FILE: .github/renovate.json5

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -24,14 +24,14 @@ jobs:
       id-token: write
       security-events: write
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Run Scorecard
-      uses: ossf/scorecard-action@v2.4.4
+      uses: ossf/scorecard-action@55891bbd73f2425e97637d96e306fc9d491d0b21 # v2.4.4
       with:
         results_file: results.sarif
         results_format: sarif
         publish_results: true
     - name: Upload Scorecard results
-      uses: github/codeql-action/upload-sarif@v4.37.6
+      uses: github/codeql-action/upload-sarif@9e3211c9a3b9311dfe05da2ed48eea3386f042dd # v4.37.6
       with:
         sarif_file: results.sarif

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -18,13 +18,13 @@ jobs:
   unit-test:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:
         python-version: '3.13'
     - name: Install uv
-      uses: astral-sh/setup-uv@v9.0.0
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
     - name: Install dependencies
       run: uv pip sync --system --strict requirements.test
     - name: pytest

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are handled on the latest released version of IP Ban Manager.
+
+## Reporting a Vulnerability
+
+Please report security concerns privately through GitHub Security Advisories:
+
+https://github.com/Wheemer/ip-ban-manager/security/advisories/new
+
+Do not open a public issue for vulnerabilities that could help someone bypass
+Home Assistant access controls, block legitimate access, or expose sensitive
+configuration details.
+
+We will review valid reports, coordinate a fix, and publish a patched release
+when needed.

--- a/custom_components/ip_ban_manager/geoip.py
+++ b/custom_components/ip_ban_manager/geoip.py
@@ -128,6 +128,7 @@ def open_geoip_download_url(url: str) -> Iterator[HTTPResponse]:
     if parsed.query:
         target = f"{target}?{parsed.query}"
     context = ssl.create_default_context()
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
     for address in geoip_resolve_download_host_via_https():
         fallback_response: HTTPResponse | None = None
         tls_socket = None

--- a/custom_components/ip_ban_manager/i18n.py
+++ b/custom_components/ip_ban_manager/i18n.py
@@ -42,6 +42,11 @@ SUPPORTED_LOCALES: frozenset[str] = frozenset(
     }
 )
 
+_PANEL_TRANSLATION_FILES = {
+    language: _PANEL_TRANSLATIONS_DIR / f"{language}.json"
+    for language in {"en", *SUPPORTED_LOCALES}
+}
+
 
 def _flatten_strings(value: object, prefix: str = "") -> dict[str, str]:
     """Flatten nested translation mappings into dotted lookup keys."""
@@ -59,7 +64,9 @@ def _flatten_strings(value: object, prefix: str = "") -> dict[str, str]:
 
 def _load_panel_file(language: str) -> dict[str, Any]:
     """Load one bundled panel locale JSON file when present."""
-    path = _PANEL_TRANSLATIONS_DIR / f"{language}.json"
+    path = _PANEL_TRANSLATION_FILES.get(language)
+    if path is None:
+        return {}
     if not path.is_file():
         return {}
     try:
@@ -105,10 +112,8 @@ def resolve_translation_language(language: str | None) -> str:
         add(tag.lower())
 
     for code in candidates:
-        if (
-            code in SUPPORTED_LOCALES
-            and (_PANEL_TRANSLATIONS_DIR / f"{code}.json").is_file()
-        ):
+        path = _PANEL_TRANSLATION_FILES.get(code)
+        if code in SUPPORTED_LOCALES and path is not None and path.is_file():
             return code
     return "en"
 


### PR DESCRIPTION
## Summary

Hardens the repository against the actionable GitHub Security tab findings.

## Changes

- Pin GitHub Actions to immutable commit SHAs while keeping readable version comments.
- Tighten workflow token permissions and use `RELEASE_TOKEN` for release asset uploads.
- Add `SECURITY.md` for private vulnerability reporting.
- Restrict panel translation loading to bundled locale files.
- Require TLS 1.2+ for the manual GeoIP fallback connection.

## Validation

Validated on `server` at `root@192.168.1.60`:

```bash
pre-commit run -a
pytest -q
```

Result: `197 passed`.
